### PR TITLE
feat: upgrade from node.js 20 to 24

### DIFF
--- a/.changeset/pretty-hats-sin.md
+++ b/.changeset/pretty-hats-sin.md
@@ -1,0 +1,5 @@
+---
+'github-actions-cloudflare-pages': minor
+---
+
+Upgrade action from node.js 20 to 24

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,8 +22,8 @@
 		"ghcr.io/devcontainers-extra/features/act:1": {},
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
 		"ghcr.io/devcontainers/features/node:1": {
-			"version": "20.19.3",
-			"pnpmVersion": "10.12.4"
+			"version": "24.7.0",
+			"pnpmVersion": "10.15.1"
 		},
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/devcontainers-extra/features/pre-commit:2": {}

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - uses: andykenward/github-actions/setup-pnpm@32471b1e0a5df8a09500a54b1254e3f0f881e52d #v1.0.3
         with:
-          node-version: 20
+          node-version: 24
       - name: Cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
           languages: ${{ matrix.language }}
       - uses: andykenward/github-actions/setup-pnpm@32471b1e0a5df8a09500a54b1254e3f0f881e52d #v1.0.3
         with:
-          node-version: 20
+          node-version: 24
       - name: Cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - uses: andykenward/github-actions/setup-pnpm@32471b1e0a5df8a09500a54b1254e3f0f881e52d #v1.0.3
         with:
-          node-version: 20
+          node-version: 24
       - name: Cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - uses: andykenward/github-actions/setup-pnpm@32471b1e0a5df8a09500a54b1254e3f0f881e52d #v1.0.3
         with:
-          node-version: 20
+          node-version: 24
       - name: Cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
         with:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - uses: andykenward/github-actions/setup-pnpm@32471b1e0a5df8a09500a54b1254e3f0f881e52d #v1.0.3
         with:
-          node-version: 20
+          node-version: 24
       - name: Cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
         with:
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - uses: andykenward/github-actions/setup-pnpm@32471b1e0a5df8a09500a54b1254e3f0f881e52d #v1.0.3
         with:
-          node-version: 20
+          node-version: 24
       - name: Cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
         with:

--- a/action.yml
+++ b/action.yml
@@ -44,5 +44,5 @@ outputs:
     description: 'Wrangler cli output'
 
 runs:
-  using: node20
+  using: node24
   main: dist/deploy/index.js

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -9,7 +9,7 @@ const config = {
   bundle: true,
   format: 'esm',
   keepNames: true,
-  target: 'node20',
+  target: 'node24',
   platform: 'node',
   sourcemap: true,
   legalComments: 'external',

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@octokit/webhooks-schemas": "7.6.1",
     "@octokit/webhooks-types": "7.6.1",
     "@total-typescript/ts-reset": "0.6.1",
-    "@tsconfig/node20": "20.1.6",
+    "@tsconfig/node24": "24.0.1",
     "@types/json-schema": "7.0.15",
     "@types/node": "24.3.1",
     "@vitest/eslint-plugin": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@total-typescript/ts-reset": "0.6.1",
     "@tsconfig/node20": "20.1.6",
     "@types/json-schema": "7.0.15",
-    "@types/node": "20.17.28",
+    "@types/node": "24.3.1",
     "@vitest/eslint-plugin": "1.3.4",
     "dotenv": "17.2.0",
     "esbuild": "0.25.8",

--- a/package.json
+++ b/package.json
@@ -89,10 +89,10 @@
   "peerDependencies": {
     "wrangler": "^4.13.2"
   },
-  "packageManager": "pnpm@10.12.4",
+  "packageManager": "pnpm@10.15.1",
   "engines": {
-    "node": "^20.19.2",
-    "pnpm": "^10.12.4"
+    "node": "^24.7.0",
+    "pnpm": "^10.15.1"
   },
   "pnpm": {
     "peerDependencyRules": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,9 +54,9 @@ importers:
       '@total-typescript/ts-reset':
         specifier: 0.6.1
         version: 0.6.1
-      '@tsconfig/node20':
-        specifier: 20.1.6
-        version: 20.1.6
+      '@tsconfig/node24':
+        specifier: 24.0.1
+        version: 24.0.1
       '@types/json-schema':
         specifier: 7.0.15
         version: 7.0.15
@@ -1425,8 +1425,8 @@ packages:
   '@total-typescript/ts-reset@0.6.1':
     resolution: {integrity: sha512-cka47fVSo6lfQDIATYqb/vO1nvFfbPw7uWLayIXIhGETj0wcOOlrlkobOMDNQOFr9QOafegUPq13V2+6vtD7yg==}
 
-  '@tsconfig/node20@20.1.6':
-    resolution: {integrity: sha512-sz+Hqx9zwZDpZIV871WSbUzSqNIsXzghZydypnfgzPKLltVJfkINfUeTct31n/tTSa9ZE1ZOfKdRre1uHHquYQ==}
+  '@tsconfig/node24@24.0.1':
+    resolution: {integrity: sha512-3+IXshza3bIrT0tbHBr9CixQDVf4iBf0HTR0hCYowhpLqkzJjswu3UY8aZWjRXZep31kYB+o2SQeD8KwIoUHYw==}
 
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
@@ -4849,7 +4849,7 @@ snapshots:
 
   '@total-typescript/ts-reset@0.6.1': {}
 
-  '@tsconfig/node20@20.1.6': {}
+  '@tsconfig/node24@24.0.1': {}
 
   '@tybys/wasm-util@0.10.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
         version: 9.32.0
       '@graphql-codegen/cli':
         specifier: 5.0.7
-        version: 5.0.7(@types/node@20.17.28)(enquirer@2.4.1)(graphql@16.11.0)(typescript@5.8.3)
+        version: 5.0.7(@types/node@24.3.1)(enquirer@2.4.1)(graphql@16.11.0)(typescript@5.8.3)
       '@graphql-codegen/client-preset':
         specifier: 4.8.3
         version: 4.8.3(graphql@16.11.0)
@@ -61,11 +61,11 @@ importers:
         specifier: 7.0.15
         version: 7.0.15
       '@types/node':
-        specifier: 20.17.28
-        version: 20.17.28
+        specifier: 24.3.1
+        version: 24.3.1
       '@vitest/eslint-plugin':
         specifier: 1.3.4
-        version: 1.3.4(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.2.4(@types/node@20.17.28)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0))
+        version: 1.3.4(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.2.4(@types/node@24.3.1)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0))
       dotenv:
         specifier: 17.2.0
         version: 17.2.0
@@ -92,7 +92,7 @@ importers:
         version: 2.12.6(graphql@16.11.0)
       knip:
         specifier: 5.62.0
-        version: 5.62.0(@types/node@20.17.28)(typescript@5.8.3)
+        version: 5.62.0(@types/node@24.3.1)(typescript@5.8.3)
       prettier:
         specifier: 3.6.2
         version: 3.6.2
@@ -113,10 +113,10 @@ importers:
         version: 7.12.0
       vite:
         specifier: 6.2.7
-        version: 6.2.7(@types/node@20.17.28)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
+        version: 6.2.7(@types/node@24.3.1)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
       vitest:
         specifier: 3.2.4
-        version: 3.2.4(@types/node@20.17.28)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.4(@types/node@24.3.1)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
       wrangler:
         specifier: ^4.13.2
         version: 4.25.0
@@ -1449,8 +1449,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@20.17.28':
-    resolution: {integrity: sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==}
+  '@types/node@24.3.1':
+    resolution: {integrity: sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -3151,8 +3151,8 @@ packages:
     resolution: {integrity: sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==}
     engines: {node: '>=0.10.0'}
 
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+  undici-types@7.10.0:
+    resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
 
   undici@5.29.0:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
@@ -3989,7 +3989,7 @@ snapshots:
       graphql: 16.11.0
       tslib: 2.6.3
 
-  '@graphql-codegen/cli@5.0.7(@types/node@20.17.28)(enquirer@2.4.1)(graphql@16.11.0)(typescript@5.8.3)':
+  '@graphql-codegen/cli@5.0.7(@types/node@24.3.1)(enquirer@2.4.1)(graphql@16.11.0)(typescript@5.8.3)':
     dependencies:
       '@babel/generator': 7.28.0
       '@babel/template': 7.27.2
@@ -4000,12 +4000,12 @@ snapshots:
       '@graphql-tools/apollo-engine-loader': 8.0.21(graphql@16.11.0)
       '@graphql-tools/code-file-loader': 8.1.21(graphql@16.11.0)
       '@graphql-tools/git-loader': 8.0.25(graphql@16.11.0)
-      '@graphql-tools/github-loader': 8.0.21(@types/node@20.17.28)(graphql@16.11.0)
+      '@graphql-tools/github-loader': 8.0.21(@types/node@24.3.1)(graphql@16.11.0)
       '@graphql-tools/graphql-file-loader': 8.0.21(graphql@16.11.0)
       '@graphql-tools/json-file-loader': 8.0.19(graphql@16.11.0)
       '@graphql-tools/load': 8.1.1(graphql@16.11.0)
-      '@graphql-tools/prisma-loader': 8.0.17(@types/node@20.17.28)(graphql@16.11.0)
-      '@graphql-tools/url-loader': 8.0.32(@types/node@20.17.28)(graphql@16.11.0)
+      '@graphql-tools/prisma-loader': 8.0.17(@types/node@24.3.1)(graphql@16.11.0)
+      '@graphql-tools/url-loader': 8.0.32(@types/node@24.3.1)(graphql@16.11.0)
       '@graphql-tools/utils': 10.9.0(graphql@16.11.0)
       '@whatwg-node/fetch': 0.10.9
       chalk: 4.1.2
@@ -4013,7 +4013,7 @@ snapshots:
       debounce: 1.2.1
       detect-indent: 6.1.0
       graphql: 16.11.0
-      graphql-config: 5.1.5(@types/node@20.17.28)(graphql@16.11.0)(typescript@5.8.3)
+      graphql-config: 5.1.5(@types/node@24.3.1)(graphql@16.11.0)(typescript@5.8.3)
       inquirer: 8.2.6
       is-glob: 4.0.3
       jiti: 1.21.7
@@ -4220,7 +4220,7 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
 
-  '@graphql-tools/executor-http@1.3.3(@types/node@20.17.28)(graphql@16.11.0)':
+  '@graphql-tools/executor-http@1.3.3(@types/node@24.3.1)(graphql@16.11.0)':
     dependencies:
       '@graphql-hive/signal': 1.0.0
       '@graphql-tools/executor-common': 0.0.4(graphql@16.11.0)
@@ -4230,7 +4230,7 @@ snapshots:
       '@whatwg-node/fetch': 0.10.9
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 16.11.0
-      meros: 1.3.1(@types/node@20.17.28)
+      meros: 1.3.1(@types/node@24.3.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@types/node'
@@ -4269,9 +4269,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@graphql-tools/github-loader@8.0.21(@types/node@20.17.28)(graphql@16.11.0)':
+  '@graphql-tools/github-loader@8.0.21(@types/node@24.3.1)(graphql@16.11.0)':
     dependencies:
-      '@graphql-tools/executor-http': 1.3.3(@types/node@20.17.28)(graphql@16.11.0)
+      '@graphql-tools/executor-http': 1.3.3(@types/node@24.3.1)(graphql@16.11.0)
       '@graphql-tools/graphql-tag-pluck': 8.3.20(graphql@16.11.0)
       '@graphql-tools/utils': 10.9.0(graphql@16.11.0)
       '@whatwg-node/fetch': 0.10.9
@@ -4349,9 +4349,9 @@ snapshots:
       graphql: 16.11.0
       tslib: 2.6.3
 
-  '@graphql-tools/prisma-loader@8.0.17(@types/node@20.17.28)(graphql@16.11.0)':
+  '@graphql-tools/prisma-loader@8.0.17(@types/node@24.3.1)(graphql@16.11.0)':
     dependencies:
-      '@graphql-tools/url-loader': 8.0.32(@types/node@20.17.28)(graphql@16.11.0)
+      '@graphql-tools/url-loader': 8.0.32(@types/node@24.3.1)(graphql@16.11.0)
       '@graphql-tools/utils': 10.9.0(graphql@16.11.0)
       '@types/js-yaml': 4.0.9
       '@whatwg-node/fetch': 0.10.9
@@ -4396,10 +4396,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@graphql-tools/url-loader@8.0.32(@types/node@20.17.28)(graphql@16.11.0)':
+  '@graphql-tools/url-loader@8.0.32(@types/node@24.3.1)(graphql@16.11.0)':
     dependencies:
       '@graphql-tools/executor-graphql-ws': 2.0.5(graphql@16.11.0)
-      '@graphql-tools/executor-http': 1.3.3(@types/node@20.17.28)(graphql@16.11.0)
+      '@graphql-tools/executor-http': 1.3.3(@types/node@24.3.1)(graphql@16.11.0)
       '@graphql-tools/executor-legacy-ws': 1.1.18(graphql@16.11.0)
       '@graphql-tools/utils': 10.9.0(graphql@16.11.0)
       '@graphql-tools/wrap': 10.1.2(graphql@16.11.0)
@@ -4870,13 +4870,13 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@20.17.28':
+  '@types/node@24.3.1':
     dependencies:
-      undici-types: 6.19.8
+      undici-types: 7.10.0
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 20.17.28
+      '@types/node': 24.3.1
 
   '@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
@@ -5023,13 +5023,13 @@ snapshots:
       '@typescript-eslint/types': 8.38.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitest/eslint-plugin@1.3.4(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.2.4(@types/node@20.17.28)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0))':
+  '@vitest/eslint-plugin@1.3.4(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.2.4(@types/node@24.3.1)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@typescript-eslint/utils': 8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.31.0(jiti@2.4.2)
     optionalDependencies:
       typescript: 5.8.3
-      vitest: 3.2.4(@types/node@20.17.28)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@types/node@24.3.1)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5041,13 +5041,13 @@ snapshots:
       chai: 5.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.2.7(@types/node@20.17.28)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.4(vite@6.2.7(@types/node@24.3.1)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.7(@types/node@20.17.28)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 6.2.7(@types/node@24.3.1)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5743,13 +5743,13 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphql-config@5.1.5(@types/node@20.17.28)(graphql@16.11.0)(typescript@5.8.3):
+  graphql-config@5.1.5(@types/node@24.3.1)(graphql@16.11.0)(typescript@5.8.3):
     dependencies:
       '@graphql-tools/graphql-file-loader': 8.0.21(graphql@16.11.0)
       '@graphql-tools/json-file-loader': 8.0.19(graphql@16.11.0)
       '@graphql-tools/load': 8.1.1(graphql@16.11.0)
       '@graphql-tools/merge': 9.1.0(graphql@16.11.0)
-      '@graphql-tools/url-loader': 8.0.32(@types/node@20.17.28)(graphql@16.11.0)
+      '@graphql-tools/url-loader': 8.0.32(@types/node@24.3.1)(graphql@16.11.0)
       '@graphql-tools/utils': 10.9.0(graphql@16.11.0)
       cosmiconfig: 8.3.6(typescript@5.8.3)
       graphql: 16.11.0
@@ -5971,10 +5971,10 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  knip@5.62.0(@types/node@20.17.28)(typescript@5.8.3):
+  knip@5.62.0(@types/node@24.3.1)(typescript@5.8.3):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
-      '@types/node': 20.17.28
+      '@types/node': 24.3.1
       fast-glob: 3.3.3
       formatly: 0.2.4
       jiti: 2.4.2
@@ -6063,9 +6063,9 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  meros@1.3.1(@types/node@20.17.28):
+  meros@1.3.1(@types/node@24.3.1):
     optionalDependencies:
-      '@types/node': 20.17.28
+      '@types/node': 24.3.1
 
   micromatch@4.0.8:
     dependencies:
@@ -6661,7 +6661,7 @@ snapshots:
 
   unc-path-regex@0.1.2: {}
 
-  undici-types@6.19.8: {}
+  undici-types@7.10.0: {}
 
   undici@5.29.0:
     dependencies:
@@ -6707,13 +6707,13 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@3.2.4(@types/node@20.17.28)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0):
+  vite-node@3.2.4(@types/node@24.3.1)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.2.7(@types/node@20.17.28)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 6.2.7(@types/node@24.3.1)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -6728,23 +6728,23 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.7(@types/node@20.17.28)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0):
+  vite@6.2.7(@types/node@24.3.1)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.8
       postcss: 8.5.6
       rollup: 4.45.1
     optionalDependencies:
-      '@types/node': 20.17.28
+      '@types/node': 24.3.1
       fsevents: 2.3.3
       jiti: 2.4.2
       tsx: 4.20.3
       yaml: 2.8.0
 
-  vitest@3.2.4(@types/node@20.17.28)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0):
+  vitest@3.2.4(@types/node@24.3.1)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.2.7(@types/node@20.17.28)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(vite@6.2.7(@types/node@24.3.1)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -6762,11 +6762,11 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.2.7(@types/node@20.17.28)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
-      vite-node: 3.2.4(@types/node@20.17.28)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 6.2.7(@types/node@24.3.1)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@24.3.1)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.17.28
+      '@types/node': 24.3.1
     transitivePeerDependencies:
       - jiti
       - less

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node24/tsconfig.json",
   "compilerOptions": {
     "tsBuildInfoFile": ".cache/.tsbuildinfo",
     "allowJs": true,


### PR DESCRIPTION
CLOSES #451 

Upgrade action from Node.js 20 to 24. GitHub Actions will not support Node.js 22.