### PR TITLE
Potential fix for code scanning alert no. 56: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
 name: test
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/andykenward/github-actions-cloudflare-pages/security/code-scanning/56](https://github.com/andykenward/github-actions-cloudflare-pages/security/code-scanning/56)

The workflow should explicitly restrict the GITHUB_TOKEN permission using the `permissions` key.  
The most secure and descriptive location is at the root of the workflow YAML file, directly after the `name:` or `on:` section. For a typical test/lint workflow as shown, `contents: read` is usually sufficient.  
To fix, insert:
```yaml
permissions:
  contents: read
```
at the root level (after the `name:` or `on:` key), applying to all jobs unless overridden. No changes are required within the `jobs:` block or individual steps. No extra methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
